### PR TITLE
Update esda to Version 2.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,8 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE
   summary: Exploratory Spatial Data Analysis
+  dev_url: https://github.com/pysal/esda
+  doc_url: https://pysal.org/esda/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
1. check the upstream

2. check the pinnings
https://github.com/pysal/esda/blob/v2.4.1/setup.py
https://github.com/pysal/esda/blob/v2.4.1/requirements.txt

3. check changelogs

The change log document did not had the needed information so the release section was used instead
https://github.com/pysal/esda/releases

The changes mentioned were bug fixes and new features

This fixes a minor (breaking) bug for environments without the `pygeos` package. It makes the `pygeos` package a soft dependency for functions in the `esda.shape` and `esda.map_comparison` modules. If you intend to use functionality from those modules, you will need to install `pygeos`. Using functions from those modules without having pygeos installed will generate an `ImportError` or `ModuleNotFoundError`, depending on the configuration for the installation.

This version merges two large new sets of functionalities:
- map correspondence measures in `esda.map_comparison`
- shape statistics in `esda.shape`

4. additional research
At the moment of the review there were no open issues in conda-forge
https://github.com/conda-forge/esda-feedstock/issues

5. add dev_url
  dev_url: https://github.com/pysal/esda

6. add doc_url
  doc_url: https://pysal.org/esda/

7. check that  pip is in the test section
9. verify the test section
10. additional tests

In order to test `esda` version `2.4.1` the following command was used:
`conda build esda-feedstock --test`
The test result was the following:
`All tests passed`

In addition the `giddy` package was used in order to test the `esda` package. 
The  pinnings for `esda` in `giddy` to use version `2.4.1`
Then the following command was used:
`conda build giddy-feedstock --test`
The test result was the following:
`All tests passed`

Based on the research and on the test results we can conclude that it is safe to update `esda` to version `2.4.1`.