### PR TITLE
esda 2.5.1 [bump build number for rebuild]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-tests-must-use-absolute-path.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   # Need to avoid error: setuptools-scm was unable to detect version !!!
   script_env:


### PR DESCRIPTION
esda 2.5.1

**Destination channel:** defaults

### Links

- [PKG-7333]

### Explanation of changes:

- bump build number for rebuild because we forgot to do it

[PKG-7333]: https://anaconda.atlassian.net/browse/PKG-7333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ