### PR TITLE
esda 2.7.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/shapely-feedstock/pr10/0d2ccab

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/shapely-feedstock/pr10/0d2ccab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
-  skip: True  # [py<310]
+  skip: True  # [py<311]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,17 +27,19 @@ requirements:
     - pip
   run:
     - python
-    - geopandas >=0.12
+    - geopandas >=0.14
     - libpysal >=4.12
-    - numpy >=1.24
-    - pandas >1.5
-    - scikit-learn >=1.2
-    - scipy >=1.9
-    - shapely >=2.0
+    - numpy >=1.26
+    - pandas >=2.1
+    - scikit-learn >=1.4
+    - scipy >=1.12
+    - shapely >=2.1
   run_constrained:
     - blas=*=openblas  # [osx and x86_64]
-    - numba >=0.57
-    - rtree >=1.0
+    - matplotlib>=3.8
+    - numba >=0.58
+    - rtree >=1.1
+    - seaborn >=0.12
 
 # Issue created: https://github.com/pysal/esda/issues/361
 # E   FloatingPointError: invalid value encountered in voronoi_polygons

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "esda" %}
-{% set version = "2.7.0" %}
+{% set version = "2.7.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pysal/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 46d6abd6f2154ee1abf3d7983d0e2edd53fc3138f43cb71769a2114967747085
+  sha256: 1e8ed7f0549274f435fb68bce8ef7539bdc74c63c0b2b110d6c907079ac55b4c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - shapely >=2.1
   run_constrained:
     - blas=*=openblas  # [osx and x86_64]
-    - matplotlib>=3.8
+    - matplotlib-base >=3.8
     - numba >=0.58
     - rtree >=1.1
     - seaborn >=0.12


### PR DESCRIPTION
esda 2.7.1 

**Destination channel:** Defaults

### Links

- [PKG-9064]
- dev_url:        https://github.com/pysal/esda/tree/v2.7.1
- conda_forge:    https://github.com/conda-forge/esda-feedstock
- pypi:           https://pypi.org/project/esda/2.7.1
- pypi inspector: https://inspector.pypi.io/project/esda/2.7.1

### Explanation of changes:

- new version number


[PKG-9064]: https://anaconda.atlassian.net/browse/PKG-9064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ