### PR TITLE
esda 2.8.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,8 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # For some reason regions.zip is not copying to the test directory in the site-package.
-    - cp   esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
-    - copy esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
+    - cp   esda/tests/regions.zip {{ test_path }}  # [not win]
+    - copy esda\tests\regions.zip {{ test_path }}  # [win]
     # test_moran_local_mv uses 'geodatasets' package which is not available
     - pytest --ignore={{ test_path }}/test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "esda" %}
-{% set version = "2.7.1" %}
+{% set version = "2.8.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pysal/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 1e8ed7f0549274f435fb68bce8ef7539bdc74c63c0b2b110d6c907079ac55b4c
+  sha256: 93e2736bb1071d875f464acb9f04ddac803bbedc5b6febfcadcedfd3edf91cd3
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
 {% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_to_elevation" %}
 
 # test_moran_local_mv uses 'geodatasets' package which is not available
-{% set deselect_tests = deselect_tests + " --ignore="   + test_path + "/test_topo.py::TestTopo::test_to_elevation" %}
+{% set deselect_tests = deselect_tests + " --ignore="   + test_path + "/test_moran_local_mv.py" %}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,16 +41,20 @@ requirements:
     - rtree >=1.1
     - seaborn >=0.12
 
+{% set test_path = "${SP_DIR}/esda/tests" %}  # [not win]
+{% set test_path = "%SP_DIR%\\esda\\tests" %}  # [win]
+
+{% set deselect_tests = "" %}
 # Issue created: https://github.com/pysal/esda/issues/361
 # E   FloatingPointError: invalid value encountered in voronoi_polygons
-{% set deselect_tests = " not test_prominence_valid" %}
-{% set deselect_tests = deselect_tests + " and not test_prominence_options" %}
-{% set deselect_tests = deselect_tests + " and not test_isolation_options" %}
-{% set deselect_tests = deselect_tests + " and not test_isolation_valid" %}
-{% set deselect_tests = deselect_tests + " and not test_to_elevation" %}
+{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_prominence_valid" %}
+{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_prominence_options" %}
+{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_isolation_options" %}
+{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_isolation_valid" %}
+{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_to_elevation" %}
 
-{% set test_path = "${SP_DIR}/esda/tests/" %}  # [not win]
-{% set test_path = "%SP_DIR%\\esda\\tests\\" %}  # [win]
+# test_moran_local_mv uses 'geodatasets' package which is not available
+{% set deselect_tests = deselect_tests + " --ignore="   + test_path + "/test_topo.py::TestTopo::test_to_elevation" %}
 
 test:
   source_files:
@@ -61,10 +65,9 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # For some reason regions.zip is not copying to the test directory in the site-package.
-    - cp esda/tests/regions.zip {{ test_path }}
-    
+    - cp esda/tests/regions.zip {{ test_path }}/
     # test_moran_local_mv uses 'geodatasets' package which is not available
-    - pytest -k '{{ deselect_tests }}' --ignore={{ test_path }}test_moran_local_mv.py ${SP_DIR}/esda/tests
+    - pytest {{ deselect_tests }} {{ test_path }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,15 +43,11 @@ requirements:
 
 # Issue created: https://github.com/pysal/esda/issues/361
 # E   FloatingPointError: invalid value encountered in voronoi_polygons
-{% set deselect_tests = " --deselect=test_topo.py::TestTopo::test_prominence_valid" %}
-{% set deselect_tests = deselect_tests + " --deselect=test_topo.py::TestTopo::test_prominence_options" %}
-{% set deselect_tests = deselect_tests + " --deselect=test_topo.py::TestTopo::test_isolation_options" %}
-{% set deselect_tests = deselect_tests + " --deselect=test_topo.py::TestTopo::test_isolation_valid" %}
-{% set deselect_tests = deselect_tests + " --deselect=test_topo.py::TestTopo::test_to_elevation" %}
-
-# Test imports 'geodatasets' package which we don't have available
-{% set deselect_tests = deselect_tests + " --ignore=test_moran_local_mv.py" %}
-
+{% set deselect_tests = " not test_prominence_valid" %}
+{% set deselect_tests = deselect_tests + " and not test_prominence_options" %}
+{% set deselect_tests = deselect_tests + " and not test_isolation_options" %}
+{% set deselect_tests = deselect_tests + " and not test_isolation_valid" %}
+{% set deselect_tests = deselect_tests + " and not test_to_elevation" %}
 
 test:
   source_files:
@@ -64,7 +60,8 @@ test:
     # For some reason regions.zip is not copying to the test directory in the site-package.
     - cp esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
     - cp esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
-    - pytest --pyargs esda.tests {{ deselect_tests }}
+    # Test test_moran_local_mv imports 'geodatasets' package which we don't have available.
+    - pytest -k '{{ deselect_tests }}' --ignore=test_moran_local_mv.py ${SP_DIR}/esda/tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,8 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # For some reason regions.zip is not copying to the test directory in the site-package.
-    - cp esda/tests/regions.zip {{ test_path }}
+    - cp esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
+    - cp esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
     # test_moran_local_mv uses 'geodatasets' package which is not available
     - pytest --ignore={{ test_path }}/test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # For some reason regions.zip is not copying to the test directory in the site-package.
-    - cp esda/tests/regions.zip {{ test_path }}/
+    - cp esda/tests/regions.zip {{ test_path }}
     # test_moran_local_mv uses 'geodatasets' package which is not available
     - pytest --ignore={{ test_path }}/test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ test:
     # For some reason regions.zip is not copying to the test directory in the site-package.
     - cp esda/tests/regions.zip {{ test_path }}/
     # test_moran_local_mv uses 'geodatasets' package which is not available
-    - pytest --ignore=test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
+    - pytest --ignore={{ test_path }}/test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,8 +60,9 @@ test:
     # For some reason regions.zip is not copying to the test directory in the site-package.
     - cp esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
     - cp esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
-    # Test test_moran_local_mv imports 'geodatasets' package which we don't have available.
-    - pytest -k '{{ deselect_tests }}' --ignore=test_moran_local_mv.py ${SP_DIR}/esda/tests
+    
+    # test_moran_local_mv uses 'geodatasets' package which is not available
+    - pytest -k '{{ deselect_tests }}' --ignore=${SP_DIR}/esda/tests/test_moran_local_mv.py ${SP_DIR}/esda/tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,9 @@ requirements:
 {% set deselect_tests = deselect_tests + " and not test_isolation_valid" %}
 {% set deselect_tests = deselect_tests + " and not test_to_elevation" %}
 
+{% set test_path = "${SP_DIR}/esda/tests/" %}  # [not win]
+{% set test_path = "%SP_DIR%\\esda\\tests\\" %}  # [win]
+
 test:
   source_files:
     - esda/tests/regions.zip
@@ -58,11 +61,10 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # For some reason regions.zip is not copying to the test directory in the site-package.
-    - cp esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
-    - cp esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
+    - cp esda/tests/regions.zip {{ test_path }}
     
     # test_moran_local_mv uses 'geodatasets' package which is not available
-    - pytest -k '{{ deselect_tests }}' --ignore=${SP_DIR}/esda/tests/test_moran_local_mv.py ${SP_DIR}/esda/tests
+    - pytest -k '{{ deselect_tests }}' --ignore={{ test_path }}test_moran_local_mv.py ${SP_DIR}/esda/tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,14 +47,11 @@ requirements:
 {% set deselect_tests = "" %}
 # Issue created: https://github.com/pysal/esda/issues/361
 # E   FloatingPointError: invalid value encountered in voronoi_polygons
-{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_prominence_valid" %}
-{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_prominence_options" %}
-{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_isolation_options" %}
-{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_isolation_valid" %}
-{% set deselect_tests = deselect_tests + " --deselect=" + test_path + "/test_topo.py::TestTopo::test_to_elevation" %}
-
-# test_moran_local_mv uses 'geodatasets' package which is not available
-{% set deselect_tests = deselect_tests + " --ignore="   + test_path + "/test_moran_local_mv.py" %}
+{% set deselect_tests = " not test_prominence_valid" %}
+{% set deselect_tests = deselect_tests + " and not test_prominence_options" %}
+{% set deselect_tests = deselect_tests + " and not test_isolation_options" %}
+{% set deselect_tests = deselect_tests + " and not test_isolation_valid" %}
+{% set deselect_tests = deselect_tests + " and not test_to_elevation" %}
 
 test:
   source_files:
@@ -67,7 +64,7 @@ test:
     # For some reason regions.zip is not copying to the test directory in the site-package.
     - cp esda/tests/regions.zip {{ test_path }}/
     # test_moran_local_mv uses 'geodatasets' package which is not available
-    - pytest {{ deselect_tests }} {{ test_path }}
+    - pytest --ignore=test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,9 @@ requirements:
 {% set deselect_tests = deselect_tests + " --deselect=test_topo.py::TestTopo::test_isolation_valid" %}
 {% set deselect_tests = deselect_tests + " --deselect=test_topo.py::TestTopo::test_to_elevation" %}
 
+# Test imports 'geodatasets' package which we don't have available
+{% set deselect_tests = deselect_tests + " --ignore=test_moran_local_mv.py" %}
+
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,8 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # For some reason regions.zip is not copying to the test directory in the site-package.
-    - cp esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
-    - cp esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
+    - cp    esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
+    - xcopy esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
     # test_moran_local_mv uses 'geodatasets' package which is not available
     - pytest --ignore={{ test_path }}/test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,8 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # For some reason regions.zip is not copying to the test directory in the site-package.
-    - cp    esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
-    - xcopy esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
+    - cp   esda/tests/regions.zip ${SP_DIR}/esda/tests/  # [not win]
+    - copy esda/tests/regions.zip %SP_DIR%/esda/tests/  # [win]
     # test_moran_local_mv uses 'geodatasets' package which is not available
     - pytest --ignore={{ test_path }}/test_moran_local_mv.py -k "not {{ deselect_tests }}" {{ test_path }}
   requires:


### PR DESCRIPTION
esda 2.8.1 

**Destination channel:** Defaults

### Links

- [PKG-11590]
- dev_url:        https://github.com/pysal/esda/tree/v2.8.1
- conda_forge:    https://github.com/conda-forge/esda-feedstock
- pypi:           https://pypi.org/project/esda/2.8.1
- pypi inspector: https://inspector.pypi.io/project/esda/2.8.1

### Explanation of changes:

- new version number


[PKG-11590]: https://anaconda.atlassian.net/browse/PKG-11590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ